### PR TITLE
fix(pretalx): missing env vars for celery

### DIFF
--- a/callforpapers/pretalx/statefulset.yaml
+++ b/callforpapers/pretalx/statefulset.yaml
@@ -125,6 +125,16 @@ spec:
                 secretKeyRef:
                   name: pretalx-cnpg-secret
                   key: password
+            - name: PRETALX_CELERY_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: pretalx-valkey
+                  key: celery-broker-url
+            - name: PRETALX_CELERY_BACKEND
+              valueFrom:
+                secretKeyRef:
+                  name: pretalx-valkey
+                  key: celery-backend-url
           volumeMounts:
             - name: pretalx-data
               mountPath: /data


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add PRETALX_CELERY_BROKER env var

- Add PRETALX_CELERY_BACKEND env var


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Pretalx StatefulSet"] -- "uses" --> B["Secret pretalx-valkey"]
  B -- "celery-broker-url → PRETALX_CELERY_BROKER" --> A
  B -- "celery-backend-url → PRETALX_CELERY_BACKEND" --> A
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Add Celery env vars to StatefulSet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

callforpapers/pretalx/statefulset.yaml

<li>Added <code>PRETALX_CELERY_BROKER</code> env var<br> <li> Added <code>PRETALX_CELERY_BACKEND</code> env var<br> <li> Sources values from secret <code>pretalx-valkey</code>


</details>


  </td>
  <td><a href="https://github.com/cloudnativefrance/cnd-platform/pull/50/files#diff-18b3bf9c96b203ae27a4c1c0f13960c88c6005e8b4b45afcf5c2de95cca8a660">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>