### PR TITLE
chore(pretalx): add a custom docker image which is configured so that  the help texts are displayed above the fields

### DIFF
--- a/callforpapers/pretalx/statefulset.yaml
+++ b/callforpapers/pretalx/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: pretalx
-          image: pretalx/standalone:v2025.1.0
+          image: smana/pretalx:v2025.1.0-cndfr-1
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Use custom pretalx Docker image


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Update pretalx container image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

callforpapers/pretalx/statefulset.yaml

- Updated container image to `smana/pretalx:v2025.1.0-cndfr-1`


</details>


  </td>
  <td><a href="https://github.com/cloudnativefrance/cnd-platform/pull/51/files#diff-18b3bf9c96b203ae27a4c1c0f13960c88c6005e8b4b45afcf5c2de95cca8a660">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>