### PR TITLE
fix(baserow): wrong secret ref for scaleway creds

### DIFF
--- a/project/baserow/helmrelease.yaml
+++ b/project/baserow/helmrelease.yaml
@@ -78,7 +78,7 @@ spec:
         amountOfGunicornWorkers: ""
         aws:
           bucketName: "cloudnativedaysfr"
-          existingSecret: "baserow-cndfrance-scw-secret"
+          existingSecret: "cnd-france-scw-secret"
           s3EndpointUrl: "https://s3.fr-par.scw.cloud"
           s3RegionName: "fr-par"
         # -- Controls how many rows can be created, deleted or updated at once using the batch endpoints.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Correct AWS S3 Scaleway secret reference

- Rename `existingSecret` to `cnd-france-scw-secret`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helmrelease.yaml</strong><dd><code>Correct Scaleway secret reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

project/baserow/helmrelease.yaml

<li>Correct AWS S3 Scaleway secret reference<br> <li> Rename <code>existingSecret</code> to <code>cnd-france-scw-secret</code>


</details>


  </td>
  <td><a href="https://github.com/cloudnativefrance/cnd-platform/pull/61/files#diff-a6e60eca923a8230626adc59fa8d7a030d7fd5f5dd5df3aa8b0e47deb8da139e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>