### PR TITLE
fix(pretalx): adding more memory, fixing oomkills

### DIFF
--- a/callforpapers/pretalx/statefulset.yaml
+++ b/callforpapers/pretalx/statefulset.yaml
@@ -96,10 +96,10 @@ spec:
               subPath: pretalx.cfg
           resources:
             requests:
-              memory: 3Gi
+              memory: 3.5Gi
               cpu: 300m
             limits:
-              memory: 3Gi
+              memory: 3.5Gi
         - name: pretalx-worker
           image: pretalx/standalone:v2025.1.0
           command:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Increase pretalx memory requests to 3.5Gi

- Increase pretalx memory limits to 3.5Gi


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml</strong><dd><code>Bump Pretalx memory allocation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

callforpapers/pretalx/statefulset.yaml

<ul><li>Updated memory <code>requests</code> from 3Gi to 3.5Gi<br> <li> Updated memory <code>limits</code> from 3Gi to 3.5Gi</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudnativefrance/cnd-platform/pull/72/files#diff-18b3bf9c96b203ae27a4c1c0f13960c88c6005e8b4b45afcf5c2de95cca8a660">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

