### PR TITLE
fix(matrix): correct chart schema violations breaking HelmRelease upgrade

### DIFF
--- a/communication/matrix/helmrelease.yaml
+++ b/communication/matrix/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
-    wellKnown:
+    wellKnownDelegation:
       ingress:
         tlsSecret: matrix-synapse-tls
 
@@ -125,23 +125,22 @@ spec:
         host: chat.cloudnativedays.fr
         tlsSecret: matrix-element-tls
       additional:
-        0-config:
-          config: |
-            {
-              "disable_custom_urls": true,
-              "brand": "Cloud Native Days France",
-              "default_theme": "dark",
-              "room_directory": {
-                "servers": ["matrix.cloudnativedays.fr"]
-              },
-              "show_labs_settings": false,
-              "default_country_code": "FR",
-              "setting_defaults": {
-                "MessageComposerInput.showStickersButton": false,
-                "UIFeature.feedback": false,
-                "UIFeature.shareSocial": false
-              }
+        0-config: |
+          {
+            "disable_custom_urls": true,
+            "brand": "Cloud Native Days France",
+            "default_theme": "dark",
+            "room_directory": {
+              "servers": ["matrix.cloudnativedays.fr"]
+            },
+            "show_labs_settings": false,
+            "default_country_code": "FR",
+            "setting_defaults": {
+              "MessageComposerInput.showStickersButton": false,
+              "UIFeature.feedback": false,
+              "UIFeature.shareSocial": false
             }
+          }
 
     postgres:
       enabled: false


### PR DESCRIPTION
## Summary
- Rename `wellKnown` to `wellKnownDelegation` (correct property name in matrix-stack chart v26.2.2)
- Fix `elementWeb.additional.0-config` to be a JSON string instead of an object with `config:` key, matching the chart's schema (`additionalProperties: { type: string }`)

These two schema violations were introduced in #100 and cause the HelmRelease upgrade to fail with:
```
- (root): Additional property wellKnown is not allowed
- elementWeb.additional.0-config: Invalid type. Expected: string, given: object
```

## Test plan
- [ ] HelmRelease reconciles successfully after merge
- [ ] Element Web loads with custom branding at chat.cloudnativedays.fr
- [ ] Well-known delegation ingress serves correct TLS certificate