### PR TITLE
fix(baserow): increase valkey memory to 512Mi

### DIFF
--- a/project/baserow/helmrelease-valkey.yaml
+++ b/project/baserow/helmrelease-valkey.yaml
@@ -30,9 +30,9 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
-        limits:
           memory: 384Mi
+        limits:
+          memory: 512Mi
       persistence:
         size: 2Gi
         storageClass: "node-local-retain"


### PR DESCRIPTION
## Summary

- Valkey keeps OOMKilling on startup — 170MB RDB data needs ~2x overhead for in-memory structures
- Increase from 384Mi to 512Mi limit (384Mi request)

## Test plan

- [ ] Valkey pod starts without OOMKill
- [ ] Backend pods can connect to Valkey and start successfully