### PR TITLE
fix(baserow): increase valkey memory to 768Mi for OOM fix

### DIFF
--- a/project/baserow/helmrelease-valkey.yaml
+++ b/project/baserow/helmrelease-valkey.yaml
@@ -30,9 +30,9 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi
         limits:
-          memory: 384Mi
+          memory: 768Mi
       persistence:
         size: 2Gi
         storageClass: "node-local-retain"


### PR DESCRIPTION
## Summary

- Valkey keeps OOMKilling on startup — 170MB RDB data needs overhead for in-memory data structures
- Increase to 768Mi limit / 512Mi request for comfortable margin

## Test plan

- [ ] Valkey pod starts without OOMKill
- [ ] Backend pods can connect to Valkey and start successfully