### PR TITLE
feat(website): deploy v1.0 at 2027.cloudnativedays.fr

### DIFF
--- a/clusters/k8s-cndfrance-prod/website.yaml
+++ b/clusters/k8s-cndfrance-prod/website.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: cnd-website
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 2m0s
+  path: ./website
+  sourceRef:
+    kind: GitRepository
+    name: customer
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: website
+      namespace: cnd-website

--- a/namespaces/namespaces.yaml
+++ b/namespaces/namespaces.yaml
@@ -23,3 +23,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cnd-ticketing
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnd-website

--- a/website/basic-auth-secret.yaml
+++ b/website/basic-auth-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: website-basic-auth
+  namespace: cnd-website
+spec:
+  encryptedData:
+    auth: AgCoI+VHVFSNVaNaR0HgaC7euYe9iysP0kNOzXjndnGNyeUaNnUQOsC67nyrFvBNtUZKNBCryDCAzJmahUrUcpNGS2yaMgTddkMNHlS2pWwg7odbapAud/MtvWJ858pj9vPbg+11kStI+MXHVMtDdkaxEZlE1df6k01JPqjz2jLU+2Eh5KnyGrR3mC1Kiz3ZYcmTcjdXieLzuQwjIborMwR9kikgYvfXn4AXaN/zn8x3sCkOroksMXHK6kMA+lnGNG0Yi4eWdOCIxWN4IAv4H5bJw4k0rDFN063uQQGnXOb8a03/0ibYcC2b028TAK75FVx/xVOWzB12oT1S5mpwd9hQvNI/iu5MOtXbbZn+Cs1STVPzjQJp15KOmJvPgB/TcGTZeNnY15u/lx0kqwo/glhwwDifLAePshYCUEPoF4OR5bs2+p3rdD8ADlQIr3TnWi7P00+lMwmSSz0jeIn5NKpPFQZdFgrYmn0Y5gpkiQmQ9D8CSKrSckkQYHztdWQ/QgH9Ljes/RZ80Na8WvJSbzdaHdzcyniJjxwPUboZmhFENm4OAbaLYEixbU6nlteUlRo0kaAfuSEJsIIFIF//70lzPAigR29pr82byRWvNmZodmePFbDbrK5tpBxGWoEfw+bAkNaVuOv0rslp69/Nvzuf2V+HprVl6SMlAc3YrHl3nBua3YJ9YAtk/rp1bX0btGjvtlqcOO53jKb5SVLVYYSl6JHidomwqW38hKBAggX2M1aBuX05PNT6gZGwM0EPS7gEfeMVGj5Ejg4Y0SEq1CPtKg==
+  template:
+    metadata:
+      creationTimestamp: null
+      name: website-basic-auth
+      namespace: cnd-website

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: website
+  namespace: cnd-website
+  labels:
+    app.kubernetes.io/name: website
+    app.kubernetes.io/component: static-site
+    app.kubernetes.io/part-of: cnd-france
+spec:
+  replicas: 2
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: website
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: website
+        app.kubernetes.io/component: static-site
+        app.kubernetes.io/part-of: cnd-france
+    spec:
+      securityContext:
+        runAsNonRoot: false
+        fsGroup: 0
+      containers:
+        - name: website
+          image: ghcr.io/cloudnativefrance/website:v1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - SETGID
+                - SETUID
+                - NET_BIND_SERVICE

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         fsGroup: 0
       containers:
         - name: website
-          image: ghcr.io/cloudnativefrance/website:v1.0
+          image: ghcr.io/cloudnativefrance/website:2956cec
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/website/ingress.yaml
+++ b/website/ingress.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: cnd-website
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    # Basic auth — staging domain is not ready for public access.
+    # Credentials stored as a SealedSecret in basic-auth-secret.yaml
+    # (bcrypt htpasswd, username 'cnd'). Rotate by sealing a new htpasswd
+    # line into the same Secret name.
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: website-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: "CND France 2027 — staging preview"
     # Temporary domain — block search-engine indexing until cutover to
     # cloudnativedays.fr. Applied at the edge so every response carries
     # the header (covers HTML, CSS, JS, images, XML sitemaps, etc.).

--- a/website/ingress.yaml
+++ b/website/ingress.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: website
+  namespace: cnd-website
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    # Temporary domain — block search-engine indexing until cutover to
+    # cloudnativedays.fr. Applied at the edge so every response carries
+    # the header (covers HTML, CSS, JS, images, XML sitemaps, etc.).
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet" always;
+spec:
+  ingressClassName: public
+  rules:
+    - host: 2027.cloudnativedays.fr
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: website
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - 2027.cloudnativedays.fr
+      secretName: website-tls

--- a/website/kustomization.yaml
+++ b/website/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cnd-website
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/website/kustomization.yaml
+++ b/website/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cnd-website
 
 resources:
+  - basic-auth-secret.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/website/service.yaml
+++ b/website/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: website
+  namespace: cnd-website
+  labels:
+    app.kubernetes.io/name: website
+    app.kubernetes.io/component: static-site
+    app.kubernetes.io/part-of: cnd-france
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: website


### PR DESCRIPTION
## Summary

Deploy the newly-shipped Cloud Native Days France website v1.0 to a temporary staging domain (`2027.cloudnativedays.fr`) ahead of cutover to the production `cloudnativedays.fr` apex.

The website repo shipped its v1.0 milestone (14 phases, 33 plans, 48/49 requirements satisfied — FNDN-07 deferred to this repo as designed). The main-branch CI build published the image at `ghcr.io/cloudnativefrance/website:2956cec`.

## Changes

- **New namespace** `cnd-website` in `namespaces/namespaces.yaml`
- **New app** `website/` with:
  - `deployment.yaml` — 2 replicas, image pinned to `:2956cec`, `imagePullPolicy: IfNotPresent`, resources `50m/64Mi req` → `200m/128Mi limits`, rolling update `maxUnavailable=0`, liveness/readiness probes on `/`
  - `service.yaml` — ClusterIP :80 → container http:8080
  - `ingress.yaml` — ingress class `public`, cert-manager `letsencrypt`, TLS secret `website-tls`, edge-level `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` so the staging domain stays out of search indexes
  - `kustomization.yaml`
- **New Flux Kustomization** `clusters/k8s-cndfrance-prod/website.yaml` — reconcile interval 2m, deployment health-check gate

## Test plan

Once merged:

- [x] DNS: create A record for `2027.cloudnativedays.fr` pointing at the ingress LB IP (same as `cfp.cloudnativedays.fr` / `tickets.cloudnativedays.fr`)
- [ ] `kubectl -n flux-system get kustomization cnd-website` → Ready=True within 2 min
- [ ] `kubectl -n cnd-website get pods` → 2/2 Running
- [ ] `kubectl -n cnd-website get certificate website-tls` → Ready=True after cert-manager issues
- [ ] `curl -I https://2027.cloudnativedays.fr` → 200 OK, `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` present
- [ ] Smoke-browse FR + EN homepages, /programme, /speakers, /replays, /sponsors, /team, /venue — all render

## Rollback

`git revert` the PR merge commit and push; Flux prunes within 2 min (`prune: true` on the Kustomization).

## Future rollouts

Next image bump is a one-liner:
\`\`\`
sed -i "s|website:[0-9a-f]\{7\}|website:\$(git -C ~/Sources/cndfrance-website rev-parse --short HEAD)|" website/deployment.yaml
\`\`\`
If you want tag-triggered semver images (e.g. `:v1.1`) for future milestones, the website repo CI needs `tags: ['v*']` added to its `on.push` filter.