### PR TITLE
fix(website): drop configuration-snippet annotation (admission denied)

### DIFF
--- a/website/ingress.yaml
+++ b/website/ingress.yaml
@@ -13,11 +13,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: website-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "CND France 2027 — staging preview"
-    # Temporary domain — block search-engine indexing until cutover to
-    # cloudnativedays.fr. Applied at the edge so every response carries
-    # the header (covers HTML, CSS, JS, images, XML sitemaps, etc.).
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet" always;
+    # Search-engine indexing protection: the basic-auth gate above blocks
+    # every crawler, so a dedicated X-Robots-Tag header is redundant. We
+    # previously set it via a configuration-snippet annotation, but that
+    # annotation class is disabled cluster-wide (nginx-ingress CVE hardening).
+    # If the gate is ever removed (e.g. cutover to cloudnativedays.fr),
+    # swap back to a noindex story before going public.
 spec:
   ingressClassName: public
   rules:


### PR DESCRIPTION
## Summary

Unblocks Flux reconciliation of the `cnd-website` Kustomization (#107). The cluster admission webhook denies `nginx.ingress.kubernetes.io/configuration-snippet` because snippet directives have been disabled cluster-wide as nginx-ingress CVE hardening.

\`\`\`
admission webhook "validate.nginx.ingress.kubernetes.io" denied the request:
nginx.ingress.kubernetes.io/configuration-snippet annotation cannot be used.
Snippet directives are disabled by the Ingress administrator
\`\`\`

The annotation set `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` to keep the staging domain out of search indexes. With basic auth in place (#107) **every crawler is already blocked at the gate**, so the header was belt-and-braces. Dropping it unblocks Flux without weakening the deployment.

## Changes

- `website/ingress.yaml`: removed the `configuration-snippet` annotation; added a comment explaining why and what to revisit at the public cutover.

## Test plan

- [x] `kustomize build website/ | kubectl apply --dry-run=server -f -` passes against the live cluster
- [ ] After merge: `kubectl -n flux-system get kustomization cnd-website` → Ready=True within 2 min
- [ ] `kubectl -n cnd-website get ingress website` → Address populated
- [ ] `curl -I https://2027.cloudnativedays.fr` → 401 Unauthorized (auth challenge intact)
- [ ] `curl -I -u cnd:<password> https://2027.cloudnativedays.fr` → 200 OK

## Future cutover note

When the site moves to the public `cloudnativedays.fr` apex, basic auth comes off. Before that:
- Reinstate noindex via either (a) `robots.txt` at the origin (baked into the build), or (b) a `server-snippet` annotation if the cluster policy allows the narrower variant, or (c) a Helm-chart values change that adds the header at the global ingress-controller level.