### PR TITLE
feat(website): automate image deploys with Flux image-automation

### DIFF
--- a/clusters/k8s-cndfrance-prod/flux-image-automation.yaml
+++ b/clusters/k8s-cndfrance-prod/flux-image-automation.yaml
@@ -1,11 +1,11 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: cnd-flux-image-automation
   namespace: flux-system
 spec:
   prune: true
-  interval: 5m0s
+  interval: 2m0s
   path: ./flux/image-automation
   dependsOn:
     - name: cnd-flux-sources

--- a/clusters/k8s-cndfrance-prod/flux-image-automation.yaml
+++ b/clusters/k8s-cndfrance-prod/flux-image-automation.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnd-flux-image-automation
+  namespace: flux-system
+spec:
+  prune: true
+  interval: 5m0s
+  path: ./flux/image-automation
+  dependsOn:
+    - name: cnd-flux-sources
+  sourceRef:
+    kind: GitRepository
+    name: customer

--- a/flux/image-automation/kustomization.yaml
+++ b/flux/image-automation/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - website.yaml

--- a/flux/image-automation/website.yaml
+++ b/flux/image-automation/website.yaml
@@ -1,0 +1,72 @@
+---
+# Scans ghcr.io/cloudnativefrance/website for new tags.
+# The package is public — no imagePullSecret needed.
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: cnd-website
+  namespace: flux-system
+spec:
+  image: ghcr.io/cloudnativefrance/website
+  interval: 5m
+---
+# Selects the most recent image built from `main`.
+#
+# Requires the upstream website CI to publish tags shaped like
+# `main-<short-sha>-<unix-ts>` (e.g. main-114f069-1729900000).
+# Until that's in place the policy will report no matching tags
+# and ImageUpdateAutomation will not change the deployment.
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: cnd-website
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: cnd-website
+  filterTags:
+    pattern: '^main-[a-f0-9]+-(?P<ts>[0-9]+)$'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc
+---
+# Watches the `customer` GitRepository, scans files under ./website
+# for `$imagepolicy` markers, and rewrites the image tag whenever
+# the ImagePolicy above resolves a newer one. Pushes the change
+# back to main so the existing cnd-website Kustomization rolls it out.
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: cnd-website
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: customer
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@cloudnativedays.fr
+        name: fluxcdbot
+      messageTemplate: |
+        chore(website): auto-update image
+
+        Files:
+        {{ range $filename, $_ := .Updated.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Images:
+        {{ range .Updated.Images -}}
+        - {{.}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./website
+    strategy: Setters

--- a/flux/image-automation/website.yaml
+++ b/flux/image-automation/website.yaml
@@ -1,6 +1,4 @@
 ---
-# Scans ghcr.io/cloudnativefrance/website for new tags.
-# The package is public — no imagePullSecret needed.
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
@@ -8,14 +6,10 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/cloudnativefrance/website
-  interval: 5m
+  interval: 30m
 ---
-# Selects the most recent image built from `main`.
-#
-# Requires the upstream website CI to publish tags shaped like
-# `main-<short-sha>-<unix-ts>` (e.g. main-114f069-1729900000).
-# Until that's in place the policy will report no matching tags
-# and ImageUpdateAutomation will not change the deployment.
+# Tag pattern requires the upstream website CI to publish images as
+# `main-<short-sha>-<unix-ts>` — Flux ImagePolicy cannot order bare git SHAs.
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
@@ -31,42 +25,24 @@ spec:
     numerical:
       order: asc
 ---
-# Watches the `customer` GitRepository, scans files under ./website
-# for `$imagepolicy` markers, and rewrites the image tag whenever
-# the ImagePolicy above resolves a newer one. Pushes the change
-# back to main so the existing cnd-website Kustomization rolls it out.
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: cnd-website
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 30m
   sourceRef:
     kind: GitRepository
     name: customer
   git:
-    checkout:
-      ref:
-        branch: main
     commit:
       author:
         email: fluxcdbot@cloudnativedays.fr
         name: fluxcdbot
       messageTemplate: |
-        chore(website): auto-update image
-
-        Files:
-        {{ range $filename, $_ := .Updated.Files -}}
-        - {{ $filename }}
-        {{ end -}}
-
-        Images:
-        {{ range .Updated.Images -}}
-        - {{.}}
-        {{ end -}}
+        chore(website): update image to {{range .Updated.Images}}{{println .}}{{end}}
     push:
       branch: main
   update:
     path: ./website
-    strategy: Setters

--- a/website/basic-auth-secret.yaml
+++ b/website/basic-auth-secret.yaml
@@ -2,7 +2,6 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  creationTimestamp: null
   name: website-basic-auth
   namespace: cnd-website
 spec:
@@ -10,6 +9,5 @@ spec:
     auth: AgCoI+VHVFSNVaNaR0HgaC7euYe9iysP0kNOzXjndnGNyeUaNnUQOsC67nyrFvBNtUZKNBCryDCAzJmahUrUcpNGS2yaMgTddkMNHlS2pWwg7odbapAud/MtvWJ858pj9vPbg+11kStI+MXHVMtDdkaxEZlE1df6k01JPqjz2jLU+2Eh5KnyGrR3mC1Kiz3ZYcmTcjdXieLzuQwjIborMwR9kikgYvfXn4AXaN/zn8x3sCkOroksMXHK6kMA+lnGNG0Yi4eWdOCIxWN4IAv4H5bJw4k0rDFN063uQQGnXOb8a03/0ibYcC2b028TAK75FVx/xVOWzB12oT1S5mpwd9hQvNI/iu5MOtXbbZn+Cs1STVPzjQJp15KOmJvPgB/TcGTZeNnY15u/lx0kqwo/glhwwDifLAePshYCUEPoF4OR5bs2+p3rdD8ADlQIr3TnWi7P00+lMwmSSz0jeIn5NKpPFQZdFgrYmn0Y5gpkiQmQ9D8CSKrSckkQYHztdWQ/QgH9Ljes/RZ80Na8WvJSbzdaHdzcyniJjxwPUboZmhFENm4OAbaLYEixbU6nlteUlRo0kaAfuSEJsIIFIF//70lzPAigR29pr82byRWvNmZodmePFbDbrK5tpBxGWoEfw+bAkNaVuOv0rslp69/Nvzuf2V+HprVl6SMlAc3YrHl3nBua3YJ9YAtk/rp1bX0btGjvtlqcOO53jKb5SVLVYYSl6JHidomwqW38hKBAggX2M1aBuX05PNT6gZGwM0EPS7gEfeMVGj5Ejg4Y0SEq1CPtKg==
   template:
     metadata:
-      creationTimestamp: null
       name: website-basic-auth
       namespace: cnd-website

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         fsGroup: 0
       containers:
         - name: website
-          image: ghcr.io/cloudnativefrance/website:114f069
+          image: ghcr.io/cloudnativefrance/website:114f069 # {"$imagepolicy": "flux-system:cnd-website"}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Adds `ImageRepository`, `ImagePolicy`, and `ImageUpdateAutomation` for the website (`flux/image-automation/website.yaml`) plus a cluster-level Flux Kustomization that loads them.
- Annotates `website/deployment.yaml` with the `$imagepolicy` marker so the automation controller knows where to rewrite the tag.
- New images pushed to `ghcr.io/cloudnativefrance/website` will be picked up, committed back to `main` by `fluxcdbot`, and reconciled by the existing `cnd-website` Kustomization — no manual deploy PR required.

## Out-of-band prerequisites (cannot live in this repo)

These are flagged in YAML comments in `flux/image-automation/website.yaml` and **must be in place for automation to actually move**. Until then the resources install cleanly but make no change (safe no-op).

1. **Install the extra controllers** — default `flux install` does not bundle them. Re-bootstrap the cluster with:
   ```
   flux bootstrap <provider> --components-extra=image-reflector-controller,image-automation-controller
   ```
2. **Write access on the `customer` GitRepository** — `ImageUpdateAutomation` reuses that source's credentials. If it was bootstrapped with a read-only deploy key, the controller will fail every push silently. Re-bootstrap with `--read-write-key` or replace the secret with a PAT/deploy key that has push rights.
3. **Sortable image tags from the website CI** — current tags are bare 7-char git SHAs (`114f069`), which `ImagePolicy` cannot order. The `cloudnativefrance/website` repo's CI must publish tags in the form `main-<short-sha>-<unix-ts>` (Flux's recommended pattern). Until that's shipped, `ImagePolicy.status.latestImage` will stay empty.

## Files

- `flux/image-automation/website.yaml` — new (3 image-automation resources, all in `flux-system`)
- `flux/image-automation/kustomization.yaml` — new
- `clusters/k8s-cndfrance-prod/flux-image-automation.yaml` — new (depends on `cnd-flux-sources`)
- `website/deployment.yaml` — appended marker comment to the `image:` line

## Test plan

- [ ] Cluster admin re-bootstraps Flux with the two extra controllers
- [ ] `kubectl get imagerepository,imagepolicy,imageupdateautomation -n flux-system` shows all three resources `Ready`
- [ ] `kubectl get imagerepository -n flux-system cnd-website -o yaml` shows scanned tags
- [ ] After website CI is updated to emit `main-<sha>-<ts>` tags, `ImagePolicy.status.latestImage` resolves to the newest one
- [ ] A new image push triggers an auto-commit on `main` and a deployment rollout
- [ ] `kubeconform` passes (CI workflow already enforces this)