### PR TITLE
fix(photos): bump museum image to a SHA that supports SMTP

### DIFF
--- a/communication/photos/museum.yaml
+++ b/communication/photos/museum.yaml
@@ -28,7 +28,12 @@ spec:
       containers:
         - name: museum
           # Image pinned to a SHA tag rather than :latest for reproducibility.
-          image: ghcr.io/ente-io/server:449284a6a119a2275928d21987453f88fbde9565
+          # NOTE: ghcr.io/ente-io/server:latest is stale (points at a 2024-03-19
+          # commit that predates SMTP support in email.go). Pinning to a recent
+          # SHA published 2026-05-11; bump by checking the tag list at
+          # https://github.com/ente-io/ente/pkgs/container/server and verifying
+          # the underlying commit date.
+          image: ghcr.io/ente-io/server:98b31e167bc5098d530c1d36f994f1a098007ff8
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Why

Museum at the previously-pinned SHA `449284a6` (2024-03-19) doesn't have SMTP support in `email.Send()`. It fell back to Zoho Transmail, found no `transmail.key`, and **silently dropped every OTP email** with `Skipping sending email to <addr>: ente Verification Code`. Signups failed with no user-facing error.

`ghcr.io/ente-io/server:latest` happens to alias the same 2024 commit (Ente has not refreshed `:latest` to a recent commit), so 'just use latest' wasn't a fix.

## What

Pin to `98b31e167bc5098d530c1d36f994f1a098007ff8` (2026-05-11), which has:

```go
func Send(...) error {
  if smtpHost := viper.GetString("smtp.host"); smtpHost != "" {
    return sendViaSMTP(...)
  }
  return sendViaTransmail(...)
}
```

Our `museum-config` already sets `smtp.host: smtp-relay.brevo.com` + `smtp.port: 587` + `smtp.encryption: tls` + the brevo-smtp SealedSecret password. Once this image rolls out, signups should send OTP via Brevo as designed.

## Verification after merge

```bash
flux --context k8s-cndfrance-prod reconcile kustomization cnd-photos
kubectl --context k8s-cndfrance-prod -n cnd-photos rollout status deploy/museum
# Then have a user retry signup; check museum logs:
kubectl --context k8s-cndfrance-prod -n cnd-photos logs deploy/museum --tail=20 | grep -iE "smtp|email|otp|sent"
# Expect a 'Sent email' or similar — not 'Skipping sending email'.
```