### PR TITLE
fix(photos): use STARTTLS not implicit TLS for Brevo on port 587

### DIFF
--- a/communication/photos/museum-config.yaml
+++ b/communication/photos/museum-config.yaml
@@ -44,7 +44,10 @@ data:
       port: 587
       username: 8f026a001@smtp-brevo.com
       email: communication@cloudnativedays.fr
-      encryption: tls
+      # encryption is intentionally unset: museum treats "tls"/"ssl" as
+      # IMPLICIT TLS (SMTPS, port 465). For Brevo's port 587 we want
+      # STARTTLS, which Go's smtp.SendMail negotiates automatically when
+      # encryption is empty and the server advertises it.
       # password ← env ENTE_SMTP_PASSWORD
 
     webauthn:


### PR DESCRIPTION
Follow-up to #131. With the newer museum image, the SMTP path is now active — but it's failing TLS:

\`\`\`
ERRO handler.go:51 Error Request failed
  Caused by: failed to establish TLS connection
  Caused by: tls: first record does not look like a TLS handshake
\`\`\`

Museum's \`sendMailWithEncryption\` only knows two modes:
- \`encryption: tls\` or \`ssl\` → implicit TLS (SMTPS, expects port 465)
- empty → \`smtp.SendMail()\` which does STARTTLS auto-upgrade

Brevo on port 587 is STARTTLS, not implicit TLS. Dropping the field unblocks the OTP path.