### PR TITLE
fix(photos): set both s3.hot_storage primary AND secondary so the override applies

### DIFF
--- a/communication/photos/museum-config.yaml
+++ b/communication/photos/museum-config.yaml
@@ -32,7 +32,13 @@ data:
 
     s3:
       hot_storage:
+        # Both primary AND secondary must be set, else museum's config code
+        # falls through to its hardcoded defaults (b2-eu-cen / wasabi…) for
+        # which we have no creds — request fails with MissingRegion.
+        # Replication is disabled, so a single-DC setup uses the same name
+        # for both.
         primary: scw-eu-fr-v3
+        secondary: scw-eu-fr-v3
       scw-eu-fr-v3:
         endpoint: s3.fr-par.scw.cloud
         region: fr-par


### PR DESCRIPTION
Museum's S3 config init silently ignores the hot_storage override unless **both** primary and secondary are set (see `s3config.go` line ~115). Without the override it picks B2/Wasabi defaults that we have no creds for, and every upload-url presign fails with `MissingRegion: could not find region configuration`.

Setting secondary to the same value as primary is harmless since replication is disabled in our deployment.