### PR TITLE
fix(photos): rename storage entry to b2-eu-cen so files register correctly

### DIFF
--- a/communication/photos/museum-config.yaml
+++ b/communication/photos/museum-config.yaml
@@ -32,18 +32,24 @@ data:
 
     s3:
       hot_storage:
-        # Both primary AND secondary must be set, else museum's config code
-        # falls through to its hardcoded defaults (b2-eu-cen / wasabi…) for
-        # which we have no creds — request fails with MissingRegion.
-        # Replication is disabled, so a single-DC setup uses the same name
-        # for both.
-        primary: scw-eu-fr-v3
-        secondary: scw-eu-fr-v3
-      scw-eu-fr-v3:
+        # Ente has a HARDCODED check (repo/file.go markAsNeedingReplication):
+        # primary hot DC must be 'b2-eu-cen' (Backblaze) or
+        # 'wasabi-eu-central-2-v3' (Wasabi). Scaleway is upstream-defined as
+        # cold-only and POST /files fails with:
+        #   only B2 and Wasabi DCs can be used as the primary hot storage
+        # Workaround (community-standard for Scaleway-only self-hosters):
+        # use 'b2-eu-cen' as the storage entry name but point endpoint/region
+        # at Scaleway. Museum doesn't validate the endpoint is actually B2.
+        # Both primary AND secondary must be set, else the override is
+        # silently ignored (the if-condition requires both non-empty).
+        # Replication is disabled, so reusing the same name for both is fine.
+        primary: b2-eu-cen
+        secondary: b2-eu-cen
+      b2-eu-cen:
         endpoint: s3.fr-par.scw.cloud
         region: fr-par
         bucket: cnd-ente-photos
-        # key/secret ← env ENTE_S3_SCW_EU_FR_V3_KEY / _SECRET
+        # key/secret ← env ENTE_S3_B2_EU_CEN_KEY / _SECRET
 
     smtp:
       host: smtp-relay.brevo.com

--- a/communication/photos/museum.yaml
+++ b/communication/photos/museum.yaml
@@ -50,14 +50,17 @@ spec:
                 secretKeyRef:
                   name: ente-cnpg-secret
                   key: password
-            # Storage entry s3.scw-eu-fr-v3 — env-var override mangling
-            # turns hyphens AND nesting into underscores.
-            - name: ENTE_S3_SCW_EU_FR_V3_KEY
+            # Storage entry name s3.b2-eu-cen — env-var override mangling
+            # turns hyphens AND nesting into underscores. The 'b2-eu-cen'
+            # name is used because Ente's repo/file.go has a hardcoded check
+            # accepting only B2 or Wasabi as primary hot DC; we point its
+            # endpoint/region at Scaleway (see museum-config.yaml).
+            - name: ENTE_S3_B2_EU_CEN_KEY
               valueFrom:
                 secretKeyRef:
                   name: cnd-france-scw-secret
                   key: access-key-id
-            - name: ENTE_S3_SCW_EU_FR_V3_SECRET
+            - name: ENTE_S3_B2_EU_CEN_SECRET
               valueFrom:
                 secretKeyRef:
                   name: cnd-france-scw-secret


### PR DESCRIPTION
Ente has a hardcoded check accepting only B2 or Wasabi as primary hot DC. Renaming our Scaleway-backed storage entry to 'b2-eu-cen' (keeping the actual endpoint/region/bucket pointed at Scaleway) lets POST /files succeed. Standard community workaround for Scaleway-only self-hosters.