### PR TITLE
chore(website): cut over ingress to cloudnativedays.fr / www.cloudnativedays.fr

### DIFF
--- a/website/ingress.yaml
+++ b/website/ingress.yaml
@@ -22,7 +22,17 @@ metadata:
 spec:
   ingressClassName: public
   rules:
-    - host: 2027.cloudnativedays.fr
+    - host: cloudnativedays.fr
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: website
+                port:
+                  name: http
+    - host: www.cloudnativedays.fr
       http:
         paths:
           - path: /
@@ -34,5 +44,6 @@ spec:
                   name: http
   tls:
     - hosts:
-        - 2027.cloudnativedays.fr
+        - cloudnativedays.fr
+        - www.cloudnativedays.fr
       secretName: website-tls


### PR DESCRIPTION

Replace the 2027.cloudnativedays.fr host with the production names and update the TLS block so cert-manager issues a certificate covering both the apex and www aliases.