### PR TITLE
chore(flux): migrate to v1 APIs + fix image-automation template

### DIFF
--- a/clusters/k8s-cndfrance-prod/callforpapers.yaml
+++ b/clusters/k8s-cndfrance-prod/callforpapers.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-callforpapers

--- a/clusters/k8s-cndfrance-prod/communication.yaml
+++ b/clusters/k8s-cndfrance-prod/communication.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-communication

--- a/clusters/k8s-cndfrance-prod/flux-image-automation.yaml
+++ b/clusters/k8s-cndfrance-prod/flux-image-automation.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-flux-image-automation

--- a/clusters/k8s-cndfrance-prod/namespaces.yaml
+++ b/clusters/k8s-cndfrance-prod/namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-namespaces

--- a/clusters/k8s-cndfrance-prod/operators.yaml
+++ b/clusters/k8s-cndfrance-prod/operators.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-operators

--- a/clusters/k8s-cndfrance-prod/photos.yaml
+++ b/clusters/k8s-cndfrance-prod/photos.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-photos

--- a/clusters/k8s-cndfrance-prod/project.yaml
+++ b/clusters/k8s-cndfrance-prod/project.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-project

--- a/clusters/k8s-cndfrance-prod/ticketing.yaml
+++ b/clusters/k8s-cndfrance-prod/ticketing.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-ticketing

--- a/clusters/k8s-cndfrance-prod/website.yaml
+++ b/clusters/k8s-cndfrance-prod/website.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cnd-website

--- a/flux/image-automation/ente-web.yaml
+++ b/flux/image-automation/ente-web.yaml
@@ -1,7 +1,7 @@
 ---
 # Tag pattern requires the upstream cndfrance-website CI to publish images as
 # `main-<short-sha>-<unix-ts>` — Flux ImagePolicy cannot order bare git SHAs.
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: cnd-ente-web-albums
@@ -10,7 +10,7 @@ spec:
   image: ghcr.io/cloudnativefrance/ente-web-albums
   interval: 30m
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: cnd-ente-web-albums
@@ -25,7 +25,7 @@ spec:
     numerical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: cnd-ente-web-accounts
@@ -34,7 +34,7 @@ spec:
   image: ghcr.io/cloudnativefrance/ente-web-accounts
   interval: 30m
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: cnd-ente-web-accounts
@@ -52,7 +52,7 @@ spec:
 # One ImageUpdateAutomation covers all three apps because they share the same
 # source repo, target path, and tag pattern. Flux scans ./photos for
 # `$imagepolicy` markers and updates each one against the matching ImagePolicy.
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: cnd-ente-web
@@ -68,7 +68,7 @@ spec:
         email: fluxcdbot@cloudnativedays.fr
         name: fluxcdbot
       messageTemplate: |
-        chore(photos): update image to {{range .Updated.Images}}{{println .}}{{end}}
+        chore(photos): update image to {{range .Changed.Images}}{{println .}}{{end}}
     push:
       branch: main
   update:

--- a/flux/image-automation/website.yaml
+++ b/flux/image-automation/website.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: cnd-website
@@ -10,7 +10,7 @@ spec:
 ---
 # Tag pattern requires the upstream website CI to publish images as
 # `main-<short-sha>-<unix-ts>` — Flux ImagePolicy cannot order bare git SHAs.
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: cnd-website
@@ -25,7 +25,7 @@ spec:
     numerical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: cnd-website
@@ -41,7 +41,7 @@ spec:
         email: fluxcdbot@cloudnativedays.fr
         name: fluxcdbot
       messageTemplate: |
-        chore(website): update image to {{range .Updated.Images}}{{println .}}{{end}}
+        chore(website): update image to {{range .Changed.Images}}{{println .}}{{end}}
     push:
       branch: main
   update:


### PR DESCRIPTION
## Why

The website Deployment was stuck on an old image (`main-bf9e5ea`) even though CI had published fresh tags. Root cause: the `cnd-website` **ImageUpdateAutomation** was `READY=False`:

> template uses removed '.Updated' field. Please use '.Changed' instead.

The image-automation-controller removed the `.Updated` field from commit-message templates. With the template failing to render, the automation never committed image-tag bumps back to git, so the Kustomization kept applying a stale revision and no rollout happened (Kustomizations stayed green — silent stall).

## What

- `flux migrate -f .` (Flux CLI **2.8.8**): bump `Kustomization` and image-automation CRs from `v1beta2` → `v1` ahead of the controller upgrade.
- Fix both `ImageUpdateAutomation` commit templates: `.Updated.Images` → `.Changed.Images` (website + ente-web). The ente-web one had the same latent bug.

## Effect

Once merged and reconciled, the `cnd-website` automation goes `READY=True`, commits the already-resolved tag (`main-485299f-…`) to `./website`, and the Deployment rolls out — finally shipping the new branded OpenGraph card.

## Verification

```
flux get image update           # cnd-website READY=True
kubectl -n cnd-website get deploy website -o jsonpath='{.spec.template.spec.containers[0].image}'
```