### PR TITLE
fix(flux): correct image-automation commit template (.Changed.Changes)

### DIFF
--- a/flux/image-automation/ente-web.yaml
+++ b/flux/image-automation/ente-web.yaml
@@ -68,7 +68,7 @@ spec:
         email: fluxcdbot@cloudnativedays.fr
         name: fluxcdbot
       messageTemplate: |
-        chore(photos): update image to {{range .Changed.Images}}{{println .}}{{end}}
+        chore(photos): update image to {{range .Changed.Changes}}{{println .NewValue}}{{end}}
     push:
       branch: main
   update:

--- a/flux/image-automation/website.yaml
+++ b/flux/image-automation/website.yaml
@@ -41,7 +41,7 @@ spec:
         email: fluxcdbot@cloudnativedays.fr
         name: fluxcdbot
       messageTemplate: |
-        chore(website): update image to {{range .Changed.Images}}{{println .}}{{end}}
+        chore(website): update image to {{range .Changed.Changes}}{{println .NewValue}}{{end}}
     push:
       branch: main
   update:


### PR DESCRIPTION
Follow-up to #141. That PR fixed the apiVersion migration but used `.Changed.Images`, which is invalid — `.Changed` is type `update.Result` and has no `Images` field, so the automation still stalled:

> can't evaluate field Images in type update.Result

Per the Flux docs (verified against fluxcd.io + context7), `.Changed` exposes `.FileChanges`, `.Objects`, and `.Changes`. Range over `.Changed.Changes` and print `.NewValue` to preserve the original "update image to <ref>" message.

Unblocks the cnd-website ImageUpdateAutomation so it can finally commit the resolved tag and roll out the website Deployment.