### PR TITLE
feat(pretalx): auto-rebuild static assets via initContainer

### DIFF
--- a/callforpapers/pretalx/statefulset.yaml
+++ b/callforpapers/pretalx/statefulset.yaml
@@ -13,6 +13,37 @@ spec:
       labels:
         app: pretalx
     spec:
+      initContainers:
+        # Regenerate static assets into the shared /public PVC on every start so the
+        # staticfiles manifest always matches the running image. The standalone
+        # entrypoint only auto-rebuilds when the static dir is MISSING, so an in-place
+        # image bump otherwise keeps stale assets and every page 500s
+        # (see docs/superpowers/specs/2026-07-19-pretalx-upgrade-design.md).
+        # Keep this image tag in sync with the containers below (Renovate bumps all).
+        - name: collect-static
+          image: pretalx/standalone:v2026.2.1
+          args: ["rebuild"]
+          env:
+            - name: PRETALX_FILESYSTEM_MEDIA
+              value: /public/media
+            - name: PRETALX_FILESYSTEM_STATIC
+              value: /public/static
+            - name: AUTOMIGRATE
+              value: "no"
+            - name: AUTOREBUILD
+              value: "no"
+          volumeMounts:
+            - name: pretalx-public
+              mountPath: /public
+            - name: pretalx-config
+              mountPath: /etc/pretalx/pretalx.cfg
+              subPath: pretalx.cfg
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 200m
+            limits:
+              memory: 3Gi
       containers:
         - name: pretalx
           image: pretalx/standalone:v2026.2.1

--- a/docs/superpowers/specs/2026-07-19-pretalx-upgrade-design.md
+++ b/docs/superpowers/specs/2026-07-19-pretalx-upgrade-design.md
@@ -143,8 +143,11 @@ pretalx runs v2026.2.1. Record for the next upgrade:
   a pod restart was needed to load the new one (`kubectl delete pod pretalx-0`, or
   wait out the CrashLoopBackOff).
 
-### Fix this for next time
-On any future pretalx image bump, the static PVC will again be stale. Options:
-force a `rebuild` on rollout (init/lifecycle that removes or repopulates
-`/public/static`), or run the two manual steps above as part of the procedure.
-Add a maintenance-window banner — the single-replica StatefulSet has real downtime.
+### Fix this for next time — DONE
+A `collect-static` **initContainer** now runs `pretalx rebuild` into the shared
+`/public` PVC on every pod start, so the staticfiles manifest always matches the
+running image and the stale-static 500 cannot recur on a future image bump. It runs
+with minimal env (config mount + `PRETALX_FILESYSTEM_*`, `AUTOMIGRATE=no`) and 3Gi
+limit (rebuild OOMs under ~1Gi). Keep its image tag in sync with the app containers
+(Renovate bumps all three together). Trade-off: ~30s added to every pod start.
+Still: the single-replica StatefulSet has real downtime on rollout — announce a window.


### PR DESCRIPTION
Prevents the stale-static `500` that took the CfP down during the v2026.2.1 upgrade (#145) from recurring on any future pretalx image bump.

## Problem
`pretalx/standalone`'s entrypoint auto-rebuilds static **only when `PRETALX_FILESYSTEM_STATIC` is missing**. Since that path is the persistent `/public/static` PVC, an in-place image bump keeps the old manifest → v2026 templates reference missing assets → `ValueError: Missing staticfiles manifest entry` → every page 500s.

## Fix
A `collect-static` initContainer runs `pretalx rebuild` into the shared `/public` PVC on every pod start, so the manifest always matches the running image.
- Invoked as `args: ["rebuild"]` through the image entrypoint (sets HOME/cwd/data-dir).
- Minimal env — verified `rebuild` needs no DB/redis/mail secrets (collectstatic + compress only).
- `AUTOMIGRATE=no` / `AUTOREBUILD=no` so the init step only rebuilds.
- 3Gi memory limit (rebuild OOMs at 700Mi; scheduling-free since main containers already sum ~4.8Gi).
- Keep the image tag in sync with the app containers — Renovate bumps all three.

Trade-off: ~30s added to each pod start. Validated with `kustomize build` + server-side `--dry-run`.

Runbook updated: `docs/superpowers/specs/2026-07-19-pretalx-upgrade-design.md`.