### PR TITLE
feat(pretalx): move valkey to the official chart, off Bitnami

### DIFF
--- a/callforpapers/pretalx/helmrelease-valkey.yaml
+++ b/callforpapers/pretalx/helmrelease-valkey.yaml
@@ -8,39 +8,55 @@ spec:
     mode: enabled
   chart:
     spec:
+      # Official Valkey project chart (upstream valkey/valkey image) — replaces the
+      # Bitnami chart, which is capped at 8.1.3 by the cluster move-to-bitnamilegacy
+      # policy. See docs/superpowers/specs/2026-07-19-pretalx-upgrade-design.md.
       chart: valkey
       sourceRef:
         kind: HelmRepository
-        name: bitnami
+        name: valkey
         namespace: flux-system
-      version: "3.0.22"
+      version: "0.10.0"
   interval: 10m0s
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   values:
+    # Name the Service exactly as the app's connection URLs expect
+    # (redis://…@pretalx-valkey-primary:6379/N, stored in the pretalx-valkey
+    # SealedSecret) so no re-seal is needed on the migration.
+    fullnameOverride: pretalx-valkey-primary
+
+    # Single-instance cache / celery broker / session store — no HA.
+    # RWO node-local PVC → Recreate so the new pod isn't blocked mounting it.
+    deploymentStrategy: Recreate
+
     auth:
-      existingSecret: "pretalx-valkey"
-      existingSecretPasswordKey: "password"
-      usePasswordFiles: false
+      enabled: true
+      # Reuse the existing secret; the default user's password is under the
+      # "password" key (same key Bitnami used).
+      usersExistingSecret: pretalx-valkey
+      aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          passwordKey: password
 
-    architecture: "standalone"
-
-    primary:
-      resourcesPreset: "nano"
-      persistence:
-        size: 2Gi
-        storageClass: "node-local-retain"
-
-    replica:
-      replicaCount: 1
-      resourcesPreset: "nano"
-
-      persistence:
-        size: 1Gi
-        storageClass: "node-local-retain"
+    dataStorage:
+      enabled: true
+      requestedSize: 2Gi
+      className: node-local-retain
 
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
+
+    resources:
+      requests:
+        memory: 128Mi
+        cpu: 100m
+      limits:
+        memory: 512Mi

--- a/flux/sources/helmrepo-valkey.yaml
+++ b/flux/sources/helmrepo-valkey.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: valkey
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://valkey.io/valkey-helm/

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helmrepo-cloudnative-pg.yaml
   - helmrepo-ess.yaml
   - helmrepo-mattermost.yaml
+  - helmrepo-valkey.yaml


### PR DESCRIPTION
Gets pretalx's valkey off the Bitnami chart (capped at 8.1.3 by the cluster `move-to-bitnamilegacy` policy — see #143) and onto the **official Valkey project chart**.

## What
- New `flux/sources/helmrepo-valkey.yaml` → `https://valkey.io/valkey-helm/`.
- `callforpapers/pretalx/helmrelease-valkey.yaml` → chart `valkey` 0.10.0 (appVersion 9.1.0), standalone.
- Image is `docker.io/valkey/valkey:9.1.0` + `ghcr.io/oliver006/redis_exporter` — **no `bitnami/*`**, so the Kyverno policy can't cap it.

## Continuity (no secret change)
- `fullnameOverride: pretalx-valkey-primary` keeps the Service name the app's connection URLs (in the `pretalx-valkey` SealedSecret) already point at → **no re-seal**.
- Auth via the existing secret (`usersExistingSecret: pretalx-valkey`, default user, `passwordKey: password`).
- `deploymentStrategy: Recreate` avoids the RWO node-local PVC mount deadlock on the single-replica Deployment.
- 2Gi persistence, ServiceMonitor on.

## Rollout
Helm swaps the `pretalx-valkey` release from the Bitnami StatefulSet to the Valkey Deployment → **brief cache blip** (sessions + in-flight celery; acceptable for a cache). Validated with `kustomize build` + `helm template`. baserow valkey to follow with the same pattern.

Recommendation write-up + rationale in the runbook.