### PR TITLE
feat(baserow): move valkey to the official chart, off Bitnami

### DIFF
--- a/project/baserow/helmrelease-valkey.yaml
+++ b/project/baserow/helmrelease-valkey.yaml
@@ -8,36 +8,55 @@ spec:
     mode: enabled
   chart:
     spec:
+      # Official Valkey project chart (upstream valkey/valkey image) — replaces the
+      # Bitnami chart, which is capped at 8.1.3 by the cluster move-to-bitnamilegacy
+      # policy. Mirrors the pretalx migration.
       chart: valkey
       sourceRef:
         kind: HelmRepository
-        name: bitnami
+        name: valkey
         namespace: flux-system
-      version: "3.0.22"
+      version: "0.10.0"
   interval: 10m0s
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   values:
+    # Keep the Service named as baserow expects (externalRedis.hostname:
+    # baserow-valkey-primary in project/baserow/helmrelease.yaml) so no config
+    # or secret change is needed.
+    fullnameOverride: baserow-valkey-primary
+
+    # Single-instance cache — no HA.
+    # RWO node-local PVC → Recreate so the new pod isn't blocked mounting it.
+    deploymentStrategy: Recreate
+
     auth:
-      existingSecret: "baserow-valkey"
-      existingSecretPasswordKey: "password"
-      usePasswordFiles: false
+      enabled: true
+      # Reuse the existing secret; default user's password under the "password" key.
+      usersExistingSecret: baserow-valkey
+      aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          passwordKey: password
 
-    architecture: "standalone"
-
-    primary:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 384Mi
-        limits:
-          memory: 512Mi
-      persistence:
-        size: 2Gi
-        storageClass: "node-local-retain"
+    dataStorage:
+      enabled: true
+      requestedSize: 2Gi
+      className: node-local-retain
 
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
+
+    # Sized for baserow's valkey OOM history (supersedes #105).
+    resources:
+      requests:
+        memory: 384Mi
+        cpu: 100m
+      limits:
+        memory: 768Mi


### PR DESCRIPTION
Same migration as pretalx (#148), applied to baserow. Gets baserow's valkey off the Bitnami chart (capped at 8.1.3 by the `move-to-bitnamilegacy` policy) onto the official Valkey project chart.

- `project/baserow/helmrelease-valkey.yaml` → chart `valkey` 0.10.0 (`docker.io/valkey/valkey:9.1.0`), standalone.
- `fullnameOverride: baserow-valkey-primary` keeps the Service name baserow's `externalRedis.hostname` points at → no secret/config change.
- Auth via existing `baserow-valkey` secret; `Recreate` strategy for the RWO PVC; ServiceMonitor on.
- **768Mi limit carries baserow's valkey OOM sizing → supersedes #105.**

Validated with `kustomize build` + `helm template`. Reuses the `valkey` HelmRepository added in #148. Brief cache blip on rollout (acceptable).