### PR TITLE
Promote to production explicitly, keep staging automatic

### DIFF
--- a/flux/image-automation/website.yaml
+++ b/flux/image-automation/website.yaml
@@ -42,7 +42,19 @@ spec:
         name: fluxcdbot
       messageTemplate: |
         chore(website): update image to {{range .Changed.Changes}}{{println .NewValue}}{{end}}
+    # Production is NOT auto-deployed. The automation writes the image bump to a
+    # promotion branch instead of main, so shipping to production is an explicit,
+    # reviewable merge rather than a side effect of merging a feature.
+    #
+    # Flux creates promote/website from main when it does not exist, so delete
+    # the branch after merging its PR and the next run recreates it cleanly.
+    #
+    # Two properties this buys back, both of which cost us today:
+    #   - a change reaches attendees only when a human decides it should;
+    #   - git owns the image field again, so `git revert` actually reverts —
+    #     with automation pushing to main, the controller overwrites any manual
+    #     edit on its next 30m run.
     push:
-      branch: main
+      branch: promote/website
   update:
     path: ./website


### PR DESCRIPTION
Production auto-deploys on every merge to the website repo's `main`. Today that shipped a visual rework nobody had looked at — the newsletter band went live because a PR merged, not because anyone judged it ready.

## The change

One line, plus the reasoning around it:

```diff
     push:
-      branch: main
+      branch: promote/website
   update:
     path: ./website
```

The automation still detects new images and still writes the correct tag — it just writes it to `promote/website` instead of `main`. Production changes when someone merges that branch.

**Staging is untouched.** It keeps `push.branch: main`, writes to `./website-staging`, and deploys immediately. That asymmetry is the point: automation where mistakes are cheap, a gate where they reach attendees.

## It also gives git back ownership of the production image field

While the automation pushed to `main`, a manual revert was overwritten within its 30m interval — the controller, not the operator, decided what ran. That was demonstrated in the session that produced this PR: the correct rollback procedure required `flux suspend` first, and `flux resume` then immediately re-deployed whatever was newest, so a suspend needed its own exit plan.

After this, rolling back production is editing a tag and pushing. No suspend, no race, no exit plan.

## Verified, not assumed

`kubectl explain imageupdateautomation.spec.git.push` on the live cluster confirms `branch` is supported on this Flux version and that the branch is created from `.spec.checkout.branch` when absent:

> Branch specifies that commits should be pushed to the branch named. The branch is created using `.spec.checkout.branch` as the starting point, if it doesn't already exist.

`kubeconform`: 3 resources, 0 invalid, 0 errors (3 skipped — Flux CRDs are not in the default schema store).

## Operational notes

- **Delete `promote/website` after merging its PR.** Flux recreates it from `main` on the next run, which keeps the history clean. Leaving it around means Flux keeps stacking commits onto a stale base.
- **`ImagePolicy cnd-website` is deliberately kept.** It deploys nothing on its own, but `flux get image policy cnd-website` still reports the newest available `main-…` tag — so you can always see what is promotable without digging through GHCR.
- **The drift risk is real and not solved here.** Production can now fall behind `main` if nobody promotes. Worth deciding separately whether that wants a scheduled check; I did not want to add machinery to a one-line config change.

## State at time of writing

Production runs `main-3c13da4-1784989588`. `main-775aa2f-1784991137` — containing the newsletter rework — is built and waiting in GHCR. Once this merges, that image ships only when someone merges `promote/website`.