### PR TITLE
Gate staging behind basic auth — it is currently public

### DIFF
--- a/website-staging/auth-sealedsecret.yaml
+++ b/website-staging/auth-sealedsecret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: website-staging-auth
+  namespace: cnd-website-staging
+spec:
+  encryptedData:
+    auth: AgA4O9Ud9a57QHJRX6MyOslnAnj0vhE8msp5MV0uSFwRWlT9ntdm97LCuFxhOjf9AL61z8kJkFz+FAW2wcDpag5B8ykHVDxdlRboIAsZvlZA3whPYW69AD9wdiQ2cXTCm7fSMScOmvAdjb1TlA7lkNk2yLadKy49au/7VWLJDdRdQlk0dcRTGazq2SfKfiMSYFG+YnU7wtFgz6yJqnmPhR6IKITj/+QDaOrKJP2iAhwpWAgWBbDLPG+jc1fsLuKi4t0KqSXDbHUJMyTob2YG1nA95H9beNVP6KcDpZ5/k6bPP4hfDkKHuX3Rr6BoDh4HS7Cv6L1O84TMZ8dltFHKJKaY0ZBBkyk46x7XfU5ncxmbz+ThAK594fG9r1bnSaP1CgsC65+5Vy1ctK9v/vST4tEXgi894oxBELfXcBoHA1xAPmQFIta1gYF5lx6nV8+JCYXDtdbqX6998p/iaN96LlCnrJ5mP0OkPHn/9GfohFxdWueY+y4RyCaYRMomnBY2/i69jMBQ/ZkWvU2iXp3K9LYZVV0MIUkFJW3DG5JndVXwesCD1lAcJpIJkdt34Rz4T5Y9u0SXvqMPGFWQFep8fIZOyaGnaj1XLMTY33gfFwLJrbbGHv4jWIh5UzWgFAYznw7prOVP1/InTELqWaFM1c1VNKQT+w+nNjeFF8wzTcumqJR7Dx2KDkLeHYuw2xeK24QVpo+ppMGINy4imdCEsInV+kU4WhpBA5ymoWh9V8TZBY/69fNNUWacrPyM4FZJfE+h0PiflkxZ6UHuhIrWJHkdhzY=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: website-staging-auth
+      namespace: cnd-website-staging

--- a/website-staging/ingress.yaml
+++ b/website-staging/ingress.yaml
@@ -1,9 +1,10 @@
 ---
-# Basic auth is deliberately absent here: the SealedSecret it would reference
-# doesn't exist yet (sealing it requires cluster access, which is the
-# operator's step). ingress-nginx returns 503 when auth-secret names a Secret
-# that isn't there, so the annotations are added in a follow-up commit once
-# the secret is sealed and applied.
+# Basic auth gate. The secret is sealed into auth-sealedsecret.yaml alongside
+# this file; ingress-nginx requires its data key to be named exactly `auth`.
+#
+# cert-manager is unaffected: its HTTP-01 solver uses a separate, more-specific
+# Ingress for /.well-known/acme-challenge/ which does not inherit these
+# annotations.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,6 +12,9 @@ metadata:
   namespace: cnd-website-staging
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: website-staging-auth
+    nginx.ingress.kubernetes.io/auth-realm: "CND France — staging"
 spec:
   ingressClassName: public
   rules:

--- a/website-staging/kustomization.yaml
+++ b/website-staging/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - auth-sealedsecret.yaml


### PR DESCRIPTION
## This closes an active exposure

`https://staging.cloudnativedays.fr/` returns **HTTP 200 to anyone right now**, with no authentication. Verified from outside the cluster:

```
$ curl -o /dev/null -w "%{http_code}" https://staging.cloudnativedays.fr/
200
```

`robots.txt` correctly serves `Disallow: /`, but that prevents *indexing*, not *access*. This environment exists to show unannounced schedule, speakers and pricing — so this becomes a real leak the moment it is used for its purpose.

The implementation plan sequenced sealing the secret and landing these annotations **before** creating the DNS record, precisely so this window could not open. The DNS record pre-existed that sequence, so the gate arrives second.

## The change

- `auth-sealedsecret.yaml` registered in the kustomization
- three `nginx.ingress.kubernetes.io/auth-*` annotations on the Ingress
- the "deliberately absent" comment replaced, since it is no longer true

The htpasswd credentials ship as a `SealedSecret`, matching the 21 already tracked in this repo. ingress-nginx requires the data key to be named exactly `auth` — verified, and the name the Ingress references matches the sealed secret.

## cert-manager is unaffected

Its HTTP-01 solver uses a separate, more-specific Ingress for `/.well-known/acme-challenge/`, which does not inherit these annotations. That is why the certificate already issued and why renewal keeps working. This was the risk flagged in the design review; it resolves in our favour.

## Verification

`kubeconform`: 3 valid, 0 invalid, 1 skipped — the skip is the `SealedSecret` CRD, absent from the default schema store, same as the Flux CRDs.

After merge I will reconcile and confirm the endpoint returns **401 without credentials and 200 with them**, rather than assuming it.